### PR TITLE
Light fix on admin notification condition

### DIFF
--- a/django_pyrogram_bot/bot/management/commands/start_bot.py
+++ b/django_pyrogram_bot/bot/management/commands/start_bot.py
@@ -57,7 +57,7 @@ class Command(BaseCommand):
         logger.info(f"Stopping bot...")
 
         # Send shutdown message to Admins
-        if bot_settings["NOTIFY_STARTUP_ADMINS"]:
+        if bot_settings["NOTIFY_SHUTDOWN_ADMINS"]:
             for admin in bot_settings["ADMINS"]:
                 client.send_message(
                         chat_id=admin,

--- a/django_pyrogram_bot/project_django_pyrogram_bot/settings.py.sample
+++ b/django_pyrogram_bot/project_django_pyrogram_bot/settings.py.sample
@@ -25,7 +25,7 @@ PYROGRAM_BOT = {
         "API_HASH": "API_HASH",
         "ADMINS": (123456,),
         "NOTIFY_STARTUP_ADMINS": True,
-        "NOTIFY_SHUTDOWN_ADMIN": True,
+        "NOTIFY_SHUTDOWN_ADMINS": True,
         }
 
 # Application definition


### PR DESCRIPTION
Shutdown notification message was relying on NOTIFY_STARTUP_ADMINS, and not on NOTIFY_SHUTDOWN_ADMINS